### PR TITLE
Changing split() to explode()

### DIFF
--- a/PHP/regDomain.inc.php
+++ b/PHP/regDomain.inc.php
@@ -39,7 +39,7 @@ function getRegisteredDomain($signingDomain, $fallback = TRUE) {
 
 	global $tldTree;
 
-	$signingDomainParts = split('\.', $signingDomain);
+	$signingDomainParts = explode('.', $signingDomain);
 
 	$result = findRegisteredDomain($signingDomainParts, $tldTree);
 


### PR DESCRIPTION
split() is deprecated as of PHP 5.3. I recommend we use explode() since it doesn't seem we really require the regular expression engine for this task.
