### PR TITLE
Fix coding style of PHP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 C/*.o
 C/libregdom.so.1
 C/test-regdom
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,21 @@
+<?php
+
+return PhpCsFixer\Config::create()
+    ->setUsingCache(true)
+    ->setRules(array(
+        'array_syntax' => ['syntax' => 'long'],
+        'combine_consecutive_unsets' => true,
+        'list_syntax' => ['syntax' => 'long'],
+        'no_closing_tag' => true,
+        'no_extra_consecutive_blank_lines' => ['break', 'continue', 'extra', 'return', 'throw', 'use', 'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block'],
+        'no_short_echo_tag' => true,
+        'no_useless_return' => true,
+	'no_whitespace_in_blank_line' => true,
+        'semicolon_after_instruction' => true,
+    ))
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->in(__DIR__)
+            ->notPath('PHP/effectiveTLDs.inc.php')
+    )
+;

--- a/PHP/effectiveTLDs.inc.php
+++ b/PHP/effectiveTLDs.inc.php
@@ -7901,4 +7901,3 @@ $tldTree = array('ac' => array('com' => array(),
 'zone' => array('triton' => array('*' => array()),
 'lima' => array()),
 'zuerich' => array());
-?>

--- a/PHP/regDomain.class.php
+++ b/PHP/regDomain.class.php
@@ -70,14 +70,11 @@ class regDomain {
 
 		// not more than 63 characters
 		if ($len>63) return FALSE;
-
 		// not less than 1 characters --> there are TLD-specific rules that could be considered additionally
 		if ($len<1) return FALSE;
-
 		// Use only letters, numbers, or hyphen ("-")
 		// not beginning or ending with a hypen (this is TLD specific, be aware!)
 		if (!preg_match("/^([a-z0-9])(([a-z0-9-])*([a-z0-9]))*$/", $domPart)) return FALSE;
-
 		return TRUE;
 	}
 
@@ -114,12 +111,7 @@ class regDomain {
 	/* load tld tree into object */
 	function __construct() {
 		/* include tld tree data */
-		include(dirname(__FILE__) . '/effectiveTLDs.inc.php');
+		include(__DIR__ . '/effectiveTLDs.inc.php');
 		$this->tldTree = $tldTree;
-
 	}
-
 }
-
-?>
-

--- a/PHP/regDomain.inc.php
+++ b/PHP/regDomain.inc.php
@@ -36,7 +36,7 @@
  */
 
 /* pull in class */
-require_once(dirname(__FILE__) . '/regDomain.class.php');
+require_once(__DIR__ . '/regDomain.class.php');
 
 /* create global object */
 $regDomainObj = new regDomain;
@@ -62,5 +62,3 @@ function findRegisteredDomain($remainingSigningDomainParts, &$treeNode) {
 	/* return object method */
 	return $regDomainObj->findRegisteredDomain($remainingSigningDomainParts, $treeNode);
 }
-
-?>

--- a/PHP/test-regDomain.php
+++ b/PHP/test-regDomain.php
@@ -38,7 +38,6 @@ $argc = $_SERVER["argc"];
 $argv = $_SERVER["argv"];
 
 for ($i=1; $i<$argc; $i++) {
-
 	$registeredDomain = getRegisteredDomain($argv[$i], $tldTree);
 
 	if ( $registeredDomain === NULL ) {
@@ -47,5 +46,3 @@ for ($i=1; $i<$argc; $i++) {
 		printf("%s\n", $registeredDomain);
 	}
 }
-
-?>

--- a/generateEffectiveTLDs.php
+++ b/generateEffectiveTLDs.php
@@ -36,9 +36,7 @@ function endsWith($search, $endstring) {
 	return (substr($search, -strlen($endstring))==$endstring);
 }
 
-
 function buildSubdomain(&$node, $tldParts) {
-
 	$dom = trim(array_pop($tldParts));
 
 	$isNotDomain = FALSE;
@@ -61,7 +59,6 @@ function buildSubdomain(&$node, $tldParts) {
 }
 
 function printNode($key, $valueTree, $isAssignment = false) {
-
 	global $format;
 
 	if ($isAssignment) {
@@ -90,7 +87,6 @@ function printNode($key, $valueTree, $isAssignment = false) {
 	$keys = array_keys($valueTree);
 
 	for ($i=0; $i<count($keys); $i++) {
-
 		$key = $keys[$i];
 
 		printNode($key, $valueTree[$key]);
@@ -112,21 +108,17 @@ function printNode($key, $valueTree, $isAssignment = false) {
 // sample: root(3:ac(5:com,edu,gov,net,ad(3:nom,co!,*)),de,com)
 
 function printNode_C($key, $valueTree) {
-
 	echo "$key";
 
 	$keys = array_keys($valueTree);
 
 	if (count($keys)>0) {
-
 		if (strcmp($keys['!'], "!")==0) {
 			echo "!";
 		} else {
-
 			echo "(".count($keys).":";
 
 			for ($i=0; $i<count($keys); $i++) {
-
 				$key = $keys[$i];
 
 				// if (count($valueTree[$key])>0) {
@@ -194,20 +186,13 @@ $tldTree = array(
 */
 
 if ($format == "c") {
-
 	echo "static const char tldString[] = \"";
 	printNode_C("root", $tldTree);
 	echo "\";\n\n";
-
 } else {
-
 	if ($format == "perl") {
 		print "package effectiveTLDs;\n\n";
 	}
 	printNode("\$tldTree", $tldTree, TRUE);
 	echo ";\n";
-	if ($format == "php") echo '?>' . "\n";
-
 }
-
-?>


### PR DESCRIPTION
The current coding style of PHP files caused some text (newlines and spaces) to be echoed. You could see an example from the PHP test script, which starts with an empty line on the shell.

I've added a minimal `php-cs-fixer` (v2) configuration in order to address this issues and some other minor code fix. To run the fixes simply do `php-cs-fixer fix` from the project root and after having installed php-cs-fixer globally.

Going further, I suggest enabling the coding style fixes for `PSR-2`, as they are de-facto standard.