### PR TITLE
Tests were failing

### DIFF
--- a/C/test-regdom.sh
+++ b/C/test-regdom.sh
@@ -43,10 +43,10 @@ b.example.uk.com: example.uk.com
 a.b.example.uk.com: example.uk.com
 test.ac: test.ac
 # TLD with only 1 (wildcard) rule.
-cy: error
-c.cy: error
-b.c.cy: b.c.cy
-a.b.c.cy: b.c.cy
+mm: error
+c.mm: error
+b.c.mm: b.c.mm
+a.b.c.mm: b.c.mm
 # More complex TLD.
 jp: error
 test.jp: test.jp


### PR DESCRIPTION
Looks like *.cy was changed a couple years ago, the test suite https://raw.githubusercontent.com/publicsuffix/list/master/tests/test_psl.txt  uses mm instead, so I changed the cy references to that and the tests pass.