### PR TITLE
Fix / mitigate passing non-array subtree to printNode_C for '!' key.

### DIFF
--- a/generateEffectiveTLDs.php
+++ b/generateEffectiveTLDs.php
@@ -129,9 +129,9 @@ function printNode_C($key, $valueTree) {
 
 				$key = $keys[$i];
 
-				// if (count($valueTree[$key])>0) {
+				if (is_array($valueTree[$key])) {
 					printNode_C($key, $valueTree[$key]);
-				// }
+				}
 
 				if ($i+1 != count($valueTree)) {
 					echo ",";


### PR DESCRIPTION
Generating C code leads to 

```
PHP Fatal error:  Uncaught TypeError: array_keys(): Argument #1 ($array) must be of type array, string given in /Users/steve/3rd/registered-domain-libs/generateEffectiveTLDs.php:118
Stack trace:
#0 /Users/steve/3rd/registered-domain-libs/generateEffectiveTLDs.php(118): array_keys('')
#1 /Users/steve/3rd/registered-domain-libs/generateEffectiveTLDs.php(133): printNode_C('!', '')
#2 /Users/steve/3rd/registered-domain-libs/generateEffectiveTLDs.php(133): printNode_C('!', Array)
#3 /Users/steve/3rd/registered-domain-libs/generateEffectiveTLDs.php(133): printNode_C('www', Array)
#4 /Users/steve/3rd/registered-domain-libs/generateEffectiveTLDs.php(199): printNode_C('ck', Array)
#5 {main}
  thrown in /Users/steve/3rd/registered-domain-libs/generateEffectiveTLDs.php on line 118
```

This PR explicitly checks for the case where the subtree is not an array and doesn't recurse. That seems to mitigate the issue, and the generated code seems to work.